### PR TITLE
feat: Add support for in-document recipe schemas if present

### DIFF
--- a/src/utils/clip.js
+++ b/src/utils/clip.js
@@ -16,17 +16,28 @@ import {
 import {
   grabByMl,
 } from './ml';
+import {
+  getImageSrcFromSchema,
+  getTitleFromSchema,
+  getDescriptionFromSchema,
+  getYieldFromSchema,
+  getIngredientsFromSchema,
+  getInstructionsFromSchema,
+} from './schema';
 
 export const clipImageURL = () => format.imageURL(
-  getSrcFromImage(grabLargestImage()),
+  getImageSrcFromSchema()
+  || getSrcFromImage(grabLargestImage()),
 );
 
 export const clipTitle = () => format.title(
-  grabLongestMatchByClasses(...ClassMatchers.title) || grabRecipeTitleFromDocumentTitle(),
+  getTitleFromSchema()
+  || grabLongestMatchByClasses(...ClassMatchers.title) || grabRecipeTitleFromDocumentTitle(),
 );
 
 export const clipDescription = () => format.description(
-  grabLongestMatchByClasses(...ClassMatchers.description),
+  getDescriptionFromSchema()
+  || grabLongestMatchByClasses(...ClassMatchers.description),
 );
 
 export const clipSource = () => format.source(
@@ -34,7 +45,8 @@ export const clipSource = () => format.source(
 );
 
 export const clipYield = () => format.yield(
-  grabLongestMatchByClasses(...ClassMatchers.yield)
+  getYieldFromSchema()
+  || grabLongestMatchByClasses(...ClassMatchers.yield)
   || closestToRegExp(matchYield).replace('\n', ''),
 );
 
@@ -48,15 +60,17 @@ export const clipTotalTime = () => format.totalTime(
   || closestToRegExp(matchTotalTime).replace('\n', ''),
 );
 
-export const clipIngredients = async () => (
-  format.ingredients(grabLongestMatchByClasses(...ClassMatchers.ingredients))
-  || format.ingredients(await grabByMl(1))
-);
+export const clipIngredients = async () => format.ingredients(
+  getIngredientsFromSchema()
+  || grabLongestMatchByClasses(...ClassMatchers.ingredients),
+)
+  || format.ingredients(await grabByMl(1));
 
-export const clipInstructions = async () => (
-  format.instructions(grabLongestMatchByClasses(...ClassMatchers.instructions))
-  || format.instructions(await grabByMl(2))
-);
+export const clipInstructions = async () => format.instructions(
+  getInstructionsFromSchema()
+  || grabLongestMatchByClasses(...ClassMatchers.instructions),
+)
+  || format.instructions(await grabByMl(2));
 
 export const clipNotes = () => format.notes(
   grabLongestMatchByClasses(...ClassMatchers.notes),

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -41,8 +41,19 @@ export const getImageSrcFromSchema = () => {
   const images = self.getPropertyFromSchema('image');
   if (!images) return '';
 
-  if (typeof images === 'string') return images;
-  if (typeof images[0] === 'string') return images[0];
+  let imageSrc;
+  if (typeof images === 'string') imageSrc = images;
+  else if (typeof images[0] === 'string') [imageSrc] = images;
+
+  if (imageSrc) {
+    try {
+      const url = new URL(imageSrc);
+
+      if (url.protocol === 'http:' || url.protocol === 'https:') return imageSrc;
+    } catch (_) {
+      // Do nothing
+    }
+  }
 
   return '';
 };

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,0 +1,100 @@
+import * as self from './schema';
+
+const longestStringIn = (strArray) => strArray.reduce((max, match) => (match.length > max.length ? match : max), '');
+
+export const getRecipeSchemasFromDocument = () => {
+  const schemas = [...document.querySelectorAll('script[type="application/ld+json"]')]
+    .map((schema) => {
+      try {
+        return JSON.parse(schema.innerText);
+      } catch (e) {
+        // Do nothing
+      }
+
+      return null;
+    })
+    .filter((e) => e);
+
+  const recipeSchemas = schemas.map((schema) => {
+    if (schema['@graph']) {
+      return schema['@graph'].find((subSchema) => subSchema['@type'] === 'Recipe');
+    }
+
+    if (schema['@type'] === 'Recipe') return schema;
+
+    return null;
+  }).filter((e) => e);
+
+  return recipeSchemas;
+};
+
+let schemas;
+export const getPropertyFromSchema = (propName) => {
+  if (!schemas) schemas = self.getRecipeSchemasFromDocument();
+
+  const foundSchema = schemas.find((schema) => schema[propName]) || {};
+
+  return foundSchema[propName] || null;
+};
+
+export const getImageSrcFromSchema = () => {
+  const images = self.getPropertyFromSchema('image');
+  if (!images) return '';
+
+  if (typeof images === 'string') return images;
+  if (typeof images[0] === 'string') return images[0];
+
+  return '';
+};
+
+export const getTitleFromSchema = () => {
+  const title = self.getPropertyFromSchema('name');
+
+  if (typeof title === 'string') return title;
+
+  return '';
+};
+
+export const getDescriptionFromSchema = () => {
+  const description = self.getPropertyFromSchema('description');
+
+  if (typeof description === 'string') return description;
+
+  return '';
+};
+
+export const getYieldFromSchema = () => {
+  const recipeYield = self.getPropertyFromSchema('recipeYield');
+  if (!recipeYield) return '';
+
+  if (typeof recipeYield === 'string') return recipeYield;
+  if (typeof recipeYield[0] === 'string') return longestStringIn(recipeYield);
+
+  return '';
+};
+
+export const getInstructionsFromSchema = () => {
+  const instructions = self.getPropertyFromSchema('recipeInstructions');
+  if (!instructions) return '';
+
+  if (typeof instructions === 'string') return instructions;
+  if (typeof instructions[0] === 'string') return instructions.join('\n');
+  if (instructions[0] && typeof instructions[0].text === 'string') {
+    return instructions.map((instruction) => instruction.text).join('\n');
+  }
+
+  return '';
+};
+
+export const getIngredientsFromSchema = () => {
+  const ingredients = self.getPropertyFromSchema('recipeIngredient');
+  if (!ingredients) return '';
+
+  if (typeof ingredients === 'string') return ingredients;
+  if (typeof ingredients[0] === 'string') return ingredients.join('\n');
+  if (ingredients[0] && typeof ingredients[0].text === 'string') {
+    return ingredients.map((ingredient) => ingredient.text).join('\n');
+  }
+
+  return '';
+};

--- a/src/utils/schema.spec.js
+++ b/src/utils/schema.spec.js
@@ -126,16 +126,28 @@ describe('getImageSrcFromSchema', () => {
     expect(getImageSrcFromSchema()).toEqual('');
   });
 
-  it('returns value when schema query result is string', () => {
-    const exampleString = 'example';
+  it('returns value when schema query result is valid url', () => {
+    const exampleString = 'https://example.com/test.jpg';
     jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
     expect(getImageSrcFromSchema()).toEqual(exampleString);
   });
 
-  it('returns first value when schema query result is array of strings', () => {
-    const exampleString = 'example';
+  it('returns first value when schema query result is array of valid urls', () => {
+    const exampleString = 'http://example.com/test.jpg';
     jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([exampleString]);
     expect(getImageSrcFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns empty string when schema query result is non-http url', () => {
+    const exampleString = 'ftp://example.com/test.jpg';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([exampleString]);
+    expect(getImageSrcFromSchema()).toEqual('');
+  });
+
+  it('returns empty string when schema query result is invalid url', () => {
+    const exampleString = 'test.jpg';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([exampleString]);
+    expect(getImageSrcFromSchema()).toEqual('');
   });
 
   it('returns empty string when schema query result is object', () => {

--- a/src/utils/schema.spec.js
+++ b/src/utils/schema.spec.js
@@ -1,0 +1,349 @@
+import * as schemaUtils from './schema';
+
+import {
+  getRecipeSchemasFromDocument,
+  getPropertyFromSchema,
+  getImageSrcFromSchema,
+  getTitleFromSchema,
+  getDescriptionFromSchema,
+  getYieldFromSchema,
+  getInstructionsFromSchema,
+  getIngredientsFromSchema,
+} from './schema';
+
+const createSchema = (schemaText) => {
+  const schema = document.createElement('script');
+  schema.type = 'application/ld+json';
+  schema.text = schemaText;
+
+  document.head.appendChild(schema);
+};
+
+describe('getRecipeSchemasFromDocument', () => {
+  afterEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('returns empty array when no schemas are present', () => {
+    expect(getRecipeSchemasFromDocument()).toEqual([]);
+  });
+
+  it('returns empty array when invalid schema is present', () => {
+    createSchema('invalid schema content');
+
+    expect(getRecipeSchemasFromDocument()).toEqual([]);
+  });
+
+  it('returns recipe schema when present', () => {
+    const recipeSchema = {
+      '@type': 'Recipe',
+    };
+    createSchema(JSON.stringify(recipeSchema));
+
+    expect(getRecipeSchemasFromDocument()).toEqual([recipeSchema]);
+  });
+
+  it('returns multiple recipe schemas when present', () => {
+    const recipeSchema = {
+      '@type': 'Recipe',
+    };
+    createSchema(JSON.stringify(recipeSchema));
+    createSchema(JSON.stringify(recipeSchema));
+
+    expect(getRecipeSchemasFromDocument()).toEqual([recipeSchema, recipeSchema]);
+  });
+
+  it('returns recipe schema from within schema graph', () => {
+    const recipeSchema = {
+      '@type': 'Recipe',
+    };
+    const graphSchema = {
+      '@graph': [recipeSchema],
+    };
+    createSchema(JSON.stringify(graphSchema));
+
+    expect(getRecipeSchemasFromDocument()).toEqual([recipeSchema]);
+  });
+
+  it('does not return non-recipe schema types', () => {
+    const nonRecipeSchema = {
+      '@type': 'Article',
+    };
+    const recipeSchema = {
+      '@type': 'Recipe',
+    };
+    createSchema(JSON.stringify(nonRecipeSchema));
+    createSchema(JSON.stringify(recipeSchema));
+
+    expect(getRecipeSchemasFromDocument()).toEqual([recipeSchema]);
+  });
+});
+
+describe('getPropertyFromSchema', () => {
+  let spy;
+  const value = 'value';
+  beforeAll(() => {
+    spy = jest.spyOn(schemaUtils, 'getRecipeSchemasFromDocument').mockReturnValue([{
+      example: value,
+    }, {
+      example: '1234',
+    }]);
+    getPropertyFromSchema('test');
+    getPropertyFromSchema('test');
+    getPropertyFromSchema('test');
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('only calls getRecipeSchemasFromDocument once', () => {
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when no schemas match', () => {
+    expect(getPropertyFromSchema('test')).toEqual(null);
+  });
+
+  it('returns value from first schema with matching element', () => {
+    expect(getPropertyFromSchema('example')).toEqual(value);
+  });
+});
+
+describe('getImageSrcFromSchema', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls getPropertyFromSchema', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema');
+    getImageSrcFromSchema();
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty string when no match is found', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(null);
+    expect(getImageSrcFromSchema()).toEqual('');
+  });
+
+  it('returns value when schema query result is string', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
+    expect(getImageSrcFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns first value when schema query result is array of strings', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([exampleString]);
+    expect(getImageSrcFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns empty string when schema query result is object', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue({
+      some: 'object',
+    });
+    expect(getImageSrcFromSchema()).toEqual('');
+  });
+
+  it('returns empty string when schema query result is array of objects', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([{
+      some: 'object',
+    }]);
+    expect(getImageSrcFromSchema()).toEqual('');
+  });
+});
+
+describe('getTitleFromSchema', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls getPropertyFromSchema', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema');
+    getTitleFromSchema();
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledTimes(1);
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledWith('name');
+  });
+
+  it('returns empty string when no match is found', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(null);
+    expect(getTitleFromSchema()).toEqual('');
+  });
+
+  it('returns value when schema query result is string', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
+    expect(getTitleFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns empty string when schema query result is not a string', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue({
+      some: 'object',
+    });
+    expect(getTitleFromSchema()).toEqual('');
+  });
+});
+
+describe('getDescriptionFromSchema', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls getPropertyFromSchema', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema');
+    getDescriptionFromSchema();
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledTimes(1);
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledWith('description');
+  });
+
+  it('returns empty string when no match is found', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(null);
+    expect(getDescriptionFromSchema()).toEqual('');
+  });
+
+  it('returns value when schema query result is string', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
+    expect(getDescriptionFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns empty string when schema query result is not a string', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue({
+      some: 'object',
+    });
+    expect(getDescriptionFromSchema()).toEqual('');
+  });
+});
+
+describe('getYieldFromSchema', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls getPropertyFromSchema', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema');
+    getYieldFromSchema();
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledTimes(1);
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledWith('recipeYield');
+  });
+
+  it('returns empty string when no match is found', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(null);
+    expect(getYieldFromSchema()).toEqual('');
+  });
+
+  it('returns value when schema query result is string', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
+    expect(getYieldFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns longest value when schema query result is an array of strings', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(['a', exampleString, 'ab']);
+    expect(getYieldFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns empty string when schema query result is not a string or array of strings', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([{
+      some: 'object',
+    }]);
+    expect(getYieldFromSchema()).toEqual('');
+  });
+});
+
+describe('getInstructionsFromSchema', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls getPropertyFromSchema', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema');
+    getInstructionsFromSchema();
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledTimes(1);
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledWith('recipeInstructions');
+  });
+
+  it('returns empty string when no match is found', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(null);
+    expect(getInstructionsFromSchema()).toEqual('');
+  });
+
+  it('returns value when schema query result is string', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
+    expect(getInstructionsFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns concatenated value when schema query result is an array of strings', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([exampleString, exampleString, exampleString]);
+    expect(getInstructionsFromSchema()).toEqual('example\nexample\nexample');
+  });
+
+  it('returns concatenated value when schema query result is an array of schemas with text', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([{
+      text: exampleString,
+    }, {
+      text: exampleString,
+    }]);
+
+    expect(getInstructionsFromSchema()).toEqual('example\nexample');
+  });
+
+  it('returns empty string when schema query result is not a string, array of strings, or array of schema objects with text', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([{
+      some: 'object',
+    }]);
+    expect(getInstructionsFromSchema()).toEqual('');
+  });
+});
+
+describe('getIngredientsFromSchema', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls getPropertyFromSchema', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema');
+    getIngredientsFromSchema();
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledTimes(1);
+    expect(schemaUtils.getPropertyFromSchema).toHaveBeenCalledWith('recipeIngredient');
+  });
+
+  it('returns empty string when no match is found', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(null);
+    expect(getIngredientsFromSchema()).toEqual('');
+  });
+
+  it('returns value when schema query result is string', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue(exampleString);
+    expect(getIngredientsFromSchema()).toEqual(exampleString);
+  });
+
+  it('returns concatenated value when schema query result is an array of strings', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([exampleString, exampleString, exampleString]);
+    expect(getIngredientsFromSchema()).toEqual('example\nexample\nexample');
+  });
+
+  it('returns concatenated value when schema query result is an array of schemas with text', () => {
+    const exampleString = 'example';
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([{
+      text: exampleString,
+    }, {
+      text: exampleString,
+    }]);
+
+    expect(getIngredientsFromSchema()).toEqual('example\nexample');
+  });
+
+  it('returns empty string when schema query result is not a string, array of strings, or array of schema objects with text', () => {
+    jest.spyOn(schemaUtils, 'getPropertyFromSchema').mockReturnValue([{
+      some: 'object',
+    }]);
+    expect(getIngredientsFromSchema()).toEqual('');
+  });
+});


### PR DESCRIPTION
This adds support for schema.org recipe schemas if present within the document. See documentation here:

https://schema.org/Recipe

https://developers.google.com/search/docs/data-types/recipe