### PR TITLE
fix: Add support for schemas that are just arrays of schemas

### DIFF
--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -16,11 +16,18 @@ export const getRecipeSchemasFromDocument = () => {
     .filter((e) => e);
 
   const recipeSchemas = schemas.map((schema) => {
+    // Schemas that evaluate to a graph
     if (schema['@graph']) {
       return schema['@graph'].find((subSchema) => subSchema['@type'] === 'Recipe');
     }
 
+    // Schemas that are directly embedded
     if (schema['@type'] === 'Recipe') return schema;
+
+    // Schemas that evaluate to an array
+    if (schema.length && schema[0]) {
+      return schema.find((subSchema) => subSchema['@type'] === 'Recipe');
+    }
 
     return null;
   }).filter((e) => e);

--- a/src/utils/schema.spec.js
+++ b/src/utils/schema.spec.js
@@ -65,6 +65,16 @@ describe('getRecipeSchemasFromDocument', () => {
     expect(getRecipeSchemasFromDocument()).toEqual([recipeSchema]);
   });
 
+  it('returns recipe schema if schema is actually an array of schemas', () => {
+    const recipeSchema = {
+      '@type': 'Recipe',
+    };
+    const arraySchema = [recipeSchema];
+    createSchema(JSON.stringify(arraySchema));
+
+    expect(getRecipeSchemasFromDocument()).toEqual([recipeSchema]);
+  });
+
   it('does not return non-recipe schema types', () => {
     const nonRecipeSchema = {
       '@type': 'Article',


### PR DESCRIPTION
Some sites (looking at you, AllRecipes), define their json-ld schemas as arrays of schemas, rather than as an `@graph` like the spec specifies. This adds support for json-ld that is just an array of schemas.